### PR TITLE
fix: preserve complete ERT programme titles

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = xmltv

--- a/tests/test_postproc.py
+++ b/tests/test_postproc.py
@@ -1,0 +1,72 @@
+import contextlib
+import io
+import unittest
+
+from lxml import etree as et
+
+from xmltv.postproc import _split_rating_and_title
+from xmltv.postproc import JsonToXmltv
+
+
+def _render_programme(title: str):
+    generator = object.__new__(JsonToXmltv)
+    generator._dataloaded = True
+    generator.json_data = [
+        {
+            "id": ["channel-01"],
+            "name": ["ERT1"],
+            "region": ["National-public"],
+            "programmes": [
+                {
+                    "airDateTime": "20260801050000 +0300",
+                    "title": title,
+                    "desc": "description",
+                }
+            ],
+        }
+    ]
+    generator.chnl_cache = {"channel-01": {"id": "1", "hashd": False}}
+    generator.root = et.Element("tv")
+    generator.xtree = et.ElementTree(generator.root)
+    generator.tree_loaded = False
+    generator.load_cache = lambda: None
+    generator.write_xml_file = lambda: None
+    with contextlib.redirect_stdout(io.StringIO()):
+        generator.generate_xmltv(write_file=False)
+    return generator.root.find("programme")
+
+
+class ProgrammeTitleParsingTests(unittest.TestCase):
+    def test_preserves_current_ert_titles_without_rating_prefix(self) -> None:
+        self.assertEqual(
+            _split_rating_and_title("Σαββατοκύριακο Ειδήσεις"),
+            ("[K16]", "Σαββατοκύριακο Ειδήσεις"),
+        )
+
+    def test_extracts_legacy_bracketed_rating(self) -> None:
+        self.assertEqual(
+            _split_rating_and_title("[K16] Δελτίο Ειδήσεων"),
+            ("[K16]", "Δελτίο Ειδήσεων"),
+        )
+
+    def test_preserves_one_word_titles(self) -> None:
+        self.assertEqual(
+            _split_rating_and_title("Ειδήσεις"),
+            ("[K16]", "Ειδήσεις"),
+        )
+
+    def test_does_not_treat_bracketed_title_text_as_rating(self) -> None:
+        self.assertEqual(
+            _split_rating_and_title("[Αθλητικά] Νέα"),
+            ("[K16]", "[Αθλητικά] Νέα"),
+        )
+
+    def test_generate_xmltv_preserves_ert_title_and_default_rating(self) -> None:
+        programme = _render_programme("Σαββατοκύριακο Ειδήσεις")
+        self.assertEqual(programme.findtext("title"), "Σαββατοκύριακο Ειδήσεις")
+        self.assertEqual(programme.findtext("rating/value"), "K16")
+
+    def test_generate_xmltv_extracts_legacy_rating(self) -> None:
+        programme = _render_programme("[K8] Δελτίο Ειδήσεων")
+        self.assertEqual(programme.findtext("title"), "Δελτίο Ειδήσεων")
+        self.assertEqual(programme.findtext("rating/value"), "K8")

--- a/xmltv/xmltv/postproc.py
+++ b/xmltv/xmltv/postproc.py
@@ -26,6 +26,8 @@ XMLTV_FILE = f'xmltv_{COUNTRY}_{LANG_GR}.xml'
 LOCAL_TZ = 'Europe/Athens'
 CACHE_DIR = 'cache/'
 CACHE_FILE = 'channels_id.json'
+DEFAULT_RATING = '[K16]'
+RATING_PREFIXES = {'[K]', '[K8]', '[K12]', '[K16]', '[K18]'}
 HD_CHANNELS = (
     # 'ERT SPORTS',   # ERT SPORTS HD
     'ALPHA',          # ALPHA HD
@@ -35,6 +37,14 @@ HD_CHANNELS = (
     'SKAI',           # SKAI HD
     'STAR'            # STAR HD
 )
+
+
+def _split_rating_and_title(programme_title: str) -> Tuple[str, str]:
+    """Extract a legacy bracketed rating without altering unprefixed titles."""
+    parts = programme_title.split(maxsplit=1)
+    if len(parts) == 2 and parts[0] in RATING_PREFIXES:
+        return parts[0], parts[1]
+    return DEFAULT_RATING, programme_title
 
 
 def get_project_root() -> str:
@@ -245,11 +255,7 @@ class JsonToXmltv:
                     "stop": stop.astimezone(timezone(LOCAL_TZ)).strftime("%Y%m%d%H%M%S %z"),
                     "channel": self.chnl_cache[station["id"][0]]["id"]}
                 programme = et.SubElement(self.root, "programme", attrib=programme_attrib)
-                try:
-                    (rating_value, title) = prgm["title"].split(maxsplit=1)
-                except ValueError:
-                    title = prgm["title"]
-                    rating_value = '[K16]'
+                rating_value, title = _split_rating_and_title(prgm["title"])
                 # programme title
                 et.SubElement(programme, "title", attrib=attrib_lang).text = title
                 # description


### PR DESCRIPTION
## Summary

- Preserve complete ERT programme titles when no legacy rating prefix is present.
- Continue parsing supported legacy `[K]`, `[K8]`, `[K12]`, `[K16]`, and `[K18]` prefixes.
- Add XML generation regression coverage and root-level pytest import configuration.

## Root cause

The XMLTV postprocessor assumed the first whitespace-delimited token in every programme title was a rating. Current ERT pages provide raw titles, so the first word was emitted as the rating and omitted from `<title>`.

## Validation

- `pytest -q`: 8 passed
- `pytest -q tests/test_postproc.py`: 6 passed
- `py_compile`, Black for the new test, and `git diff --check` passed

Closes #152